### PR TITLE
Force parameter encoding to UTF-8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.3.1
+
+- Force encoding of api\_user, api\_password, api\_url to `utf-8` to work with
+older pycurl versions
+
 # 0.3.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: icinga2
 name: icinga2
 description: Icinga2 Integration pack
-version: 0.3.0
+version: 0.3.1
 author: Igor Cherkaev
 email: emptywee@protonmail.ch

--- a/sensors/lib/client.py
+++ b/sensors/lib/client.py
@@ -17,9 +17,9 @@ class Client:
         self.conn = None
         self.buffer = ''
         self.keep_trying = 1
-        self.api_url = api_url
-        self.api_user = api_user
-        self.api_password = api_password
+        self.api_url = api_url.encode('utf-8')
+        self.api_user = api_user.encode('utf-8')
+        self.api_password = api_password.encode('utf-8')
 
         signal.signal(signal.SIGINT, self.handle_ctrl_c)
 


### PR DESCRIPTION
Users are having issues with this sensor, due to the older version of pycurl in use not accepting unicode objects. https://github.com/StackStorm/st2contrib/issues/644

See http://pycurl.io/docs/latest/unicode.html#legacy-pycurl-versions

This change forces the encoding to utf-8. 

It's probably not the best fix, but it works as a workaround.

Probably a better fix is to use a newer version of pycurl. Very quick initial testing indicated there may be some other issues with this, at least on my test Ubuntu Trusty system.